### PR TITLE
Rename package to solana-forwarder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,15 +1181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "forwarder"
-version = "0.1.0"
-dependencies = [
- "rocket",
- "solana-client",
- "tokio",
-]
-
-[[package]]
 name = "futures"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3292,6 +3283,15 @@ dependencies = [
  "solana-version",
  "spl-memo",
  "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "solana-forwarder"
+version = "0.1.0"
+dependencies = [
+ "rocket",
+ "solana-client",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
-name = "forwarder"
+name = "solana-forwarder"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 rocket = "0.5.0-rc.2"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,3 @@
 1) Set the `solana_endpoint` environment var.
 2) hit <HOST>/healthCheck with a `get`
 3) The forwarder will POST to the https://docs.solana.com/developing/clients/jsonrpc-api#gethealth endpoint on your specified Solana endpoint.
-
-
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,19 @@
-#[macro_use] extern crate rocket;
+#[macro_use]
+extern crate rocket;
 use solana_client::rpc_client::RpcClient;
 use std::env;
-
-
 
 #[get("/healthCheck")]
 async fn health_check() -> String {
     let solana_endpoint = env::var("SOLANA_ENDPOINT").expect("SOLANA_ENDPOINT not set");
     let rpc: RpcClient = RpcClient::new(solana_endpoint);
     let response = rpc.get_health();
-    
+
     match response {
         Ok(_) => String::from("Health Ok!"),
         Err(e) => format!("Error: {:?}", e),
     }
 }
-
 
 #[launch]
 #[tokio::main]


### PR DESCRIPTION
Makes it slightly easier to package it for `cargo deb` with the name `solana-forwarder`.